### PR TITLE
Refactor providers and services to use DI container

### DIFF
--- a/src/data/providers/chukyo-univ/alboProvider.ts
+++ b/src/data/providers/chukyo-univ/alboProvider.ts
@@ -1,3 +1,5 @@
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { httpClient } from "@/src/data/clients/httpClient";
 import { CUService } from "@/src/domain/constants/chukyo-univ";
 import { ALBO_URLS } from "@/src/utils/urls";
@@ -81,5 +83,7 @@ export class IntegratedAlboProvider extends abstractChukyoProvider implements Al
     }
 }
 
-const alboProviderInstance = new IntegratedAlboProvider();
+diContainer.registerSingleton(DI_TOKENS.alboProvider, () => new IntegratedAlboProvider());
+
+const alboProviderInstance = diContainer.resolve<AlboProvider>(DI_TOKENS.alboProvider);
 export default alboProviderInstance;

--- a/src/data/providers/chukyo-univ/cubicsProvider.ts
+++ b/src/data/providers/chukyo-univ/cubicsProvider.ts
@@ -1,3 +1,5 @@
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { httpClient } from "@/src/data/clients/httpClient";
 import { CUService } from "@/src/domain/constants/chukyo-univ";
 import { CUBICS_URLS } from "@/src/utils/urls";
@@ -81,5 +83,7 @@ export class IntegratedCubicsProvider extends abstractChukyoProvider implements 
     }
 }
 
-const cubicsProviderInstance = new IntegratedCubicsProvider();
+diContainer.registerSingleton(DI_TOKENS.cubicsProvider, () => new IntegratedCubicsProvider());
+
+const cubicsProviderInstance = diContainer.resolve<CubicsProvider>(DI_TOKENS.cubicsProvider);
 export default cubicsProviderInstance;

--- a/src/data/providers/chukyo-univ/manaboProvider.ts
+++ b/src/data/providers/chukyo-univ/manaboProvider.ts
@@ -1,3 +1,5 @@
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { httpClient } from "@/src/data/clients/httpClient";
 import { CUService } from "@/src/domain/constants/chukyo-univ";
 import { MANABO_URLS } from "@/src/utils/urls";
@@ -75,5 +77,7 @@ export class IntegratedManaboProvider extends abstractChukyoProvider implements 
     }
 }
 
-const manaboProviderInstance = new IntegratedManaboProvider();
+diContainer.registerSingleton(DI_TOKENS.manaboProvider, () => new IntegratedManaboProvider());
+
+const manaboProviderInstance = diContainer.resolve<ManaboProvider>(DI_TOKENS.manaboProvider);
 export default manaboProviderInstance;

--- a/src/data/providers/firebase/remoteConfigProvider.ts
+++ b/src/data/providers/firebase/remoteConfigProvider.ts
@@ -1,3 +1,5 @@
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { fetchAndActivate, getRemoteConfig, setDefaults } from "@react-native-firebase/remote-config";
 
 export interface RemoteConfigProvider {
@@ -32,5 +34,7 @@ export class IntegratedRemoteConfigProvider implements RemoteConfigProvider {
     }
 }
 
-const remoteConfigProviderInstance = new IntegratedRemoteConfigProvider();
+diContainer.registerSingleton(DI_TOKENS.remoteConfigProvider, () => new IntegratedRemoteConfigProvider());
+
+const remoteConfigProviderInstance = diContainer.resolve<RemoteConfigProvider>(DI_TOKENS.remoteConfigProvider);
 export default remoteConfigProviderInstance;

--- a/src/data/providers/palapi/palapiProvider.ts
+++ b/src/data/providers/palapi/palapiProvider.ts
@@ -1,3 +1,5 @@
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { httpClient } from "@/src/data/clients/httpClient";
 import { PALAPI_URLS } from "@/src/utils/urls";
 
@@ -63,5 +65,7 @@ export class IntegratedPalAPIProvider implements PalAPIProvider {
     }
 }
 
-const palAPIProviderInstance = new IntegratedPalAPIProvider();
+diContainer.registerSingleton(DI_TOKENS.palAPIProvider, () => new IntegratedPalAPIProvider());
+
+const palAPIProviderInstance = diContainer.resolve<PalAPIProvider>(DI_TOKENS.palAPIProvider);
 export default palAPIProviderInstance;

--- a/src/data/repositories/adminRepository.ts
+++ b/src/data/repositories/adminRepository.ts
@@ -1,3 +1,5 @@
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { getRemoteConfig, getValue } from "@react-native-firebase/remote-config";
 
 export interface AdminRepository {
@@ -22,5 +24,7 @@ export class IntegratedAdminRepository implements AdminRepository {
     }
 }
 
-const adminRepositoryInstance = new IntegratedAdminRepository();
+diContainer.registerSingleton(DI_TOKENS.adminRepository, () => new IntegratedAdminRepository());
+
+const adminRepositoryInstance = diContainer.resolve<AdminRepository>(DI_TOKENS.adminRepository);
 export default adminRepositoryInstance;

--- a/src/data/repositories/assignmentRepository.ts
+++ b/src/data/repositories/assignmentRepository.ts
@@ -1,7 +1,10 @@
 import * as parser from "@chukyo-passpal/web_parser";
 
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { ParseError } from "../errors/ParseError";
-import manaboProviderInstance, { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
+import "../providers/chukyo-univ/manaboProvider";
+import type { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
 
 export interface AssignmentRepository {
     /**
@@ -34,7 +37,7 @@ export class IntegratedAssignmentRepository implements AssignmentRepository {
      * リポジトリを初期化します。
      * @param manaboProvider Manaboプロバイダーの差し替え用インスタンス
      */
-    constructor({ manaboProvider = manaboProviderInstance }: { manaboProvider?: ManaboProvider } = {}) {
+    constructor({ manaboProvider }: { manaboProvider: ManaboProvider }) {
         this.manaboProvider = manaboProvider;
     }
 
@@ -59,5 +62,11 @@ export class IntegratedAssignmentRepository implements AssignmentRepository {
     }
 }
 
-const assignmentRepositoryInstance = new IntegratedAssignmentRepository();
+diContainer.registerSingleton(DI_TOKENS.assignmentRepository, (container) =>
+    new IntegratedAssignmentRepository({
+        manaboProvider: container.resolve<ManaboProvider>(DI_TOKENS.manaboProvider),
+    })
+);
+
+const assignmentRepositoryInstance = diContainer.resolve<AssignmentRepository>(DI_TOKENS.assignmentRepository);
 export default assignmentRepositoryInstance;

--- a/src/data/repositories/authRepository.ts
+++ b/src/data/repositories/authRepository.ts
@@ -1,7 +1,11 @@
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { getRemoteConfig, getValue } from "@react-native-firebase/remote-config";
+import "../providers/chukyo-univ/manaboProvider";
+import "../providers/palapi/palapiProvider";
 
-import manaboProviderInstance from "../providers/chukyo-univ/manaboProvider";
-import palAPIProviderInstance from "../providers/palapi/palapiProvider";
+import type { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
+import type { PalAPIProvider } from "../providers/palapi/palapiProvider";
 
 export interface AuthRepository {
     /**
@@ -21,10 +25,19 @@ export interface AuthRepository {
      * @returns 認証成功可否のPromise
      */
     authTest: (studentId: string, cuIdPass: string) => Promise<boolean>;
+
+    /**
+     * Firebase IDトークンを用いてPalAPIにログインします。
+     * @param firebaseIdToken Firebaseが発行したIDトークン
+     */
+    login: (firebaseIdToken: string) => Promise<string>;
 }
 
 export class IntegratedAuthRepository implements AuthRepository {
-    private manaboProvider = manaboProviderInstance;
+    constructor(
+        private readonly manaboProvider: ManaboProvider,
+        private readonly palAPIProvider: PalAPIProvider
+    ) {}
 
     get allowedMailDomain(): string {
         return getValue(getRemoteConfig(), "allowedMailDomain").asString();
@@ -39,11 +52,18 @@ export class IntegratedAuthRepository implements AuthRepository {
     }
 
     public login(firebaseIdToken: string) {
-        palAPIProviderInstance.post("/account/login", {
+        return this.palAPIProvider.post("/account/login", {
             bearer: firebaseIdToken,
         });
     }
 }
 
-const authRepositoryInstance = new IntegratedAuthRepository();
+diContainer.registerSingleton(DI_TOKENS.authRepository, (container) =>
+    new IntegratedAuthRepository(
+        container.resolve<ManaboProvider>(DI_TOKENS.manaboProvider),
+        container.resolve<PalAPIProvider>(DI_TOKENS.palAPIProvider)
+    )
+);
+
+const authRepositoryInstance = diContainer.resolve<AuthRepository>(DI_TOKENS.authRepository);
 export default authRepositoryInstance;

--- a/src/data/repositories/classRepository.ts
+++ b/src/data/repositories/classRepository.ts
@@ -7,7 +7,10 @@ import {
     ManaboDirectoryInfo,
     PortalRecordedAttendance,
 } from "@/src/domain/models/class";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { ParseError } from "../errors/ParseError";
+import "../providers/chukyo-univ/manaboProvider";
 import {
     classDirectoryToDomain,
     classNewsToDomain,
@@ -15,7 +18,7 @@ import {
     entryToDomain,
     manaboContentToDomain,
 } from "../mappers/classMapper";
-import manaboProviderInstance, { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
+import type { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
 
 export interface ClassRepository {
     /**
@@ -102,7 +105,7 @@ export class IntegratedClassRepository implements ClassRepository {
      * リポジトリを初期化します。
      * @param manaboProvider Manaboプロバイダーの差し替え用インスタンス
      */
-    constructor({ manaboProvider = manaboProviderInstance }: { manaboProvider?: ManaboProvider } = {}) {
+    constructor({ manaboProvider }: { manaboProvider: ManaboProvider }) {
         this.manaboProvider = manaboProvider;
     }
 
@@ -243,5 +246,11 @@ export class IntegratedClassRepository implements ClassRepository {
     }
 }
 
-const classRepositoryInstance = new IntegratedClassRepository();
+diContainer.registerSingleton(DI_TOKENS.classRepository, (container) =>
+    new IntegratedClassRepository({
+        manaboProvider: container.resolve<ManaboProvider>(DI_TOKENS.manaboProvider),
+    })
+);
+
+const classRepositoryInstance = diContainer.resolve<ClassRepository>(DI_TOKENS.classRepository);
 export default classRepositoryInstance;

--- a/src/data/repositories/mailRepository.ts
+++ b/src/data/repositories/mailRepository.ts
@@ -1,9 +1,12 @@
 import * as parser from "@chukyo-passpal/web_parser";
 
 import { ManaboMailInfo } from "@/src/domain/models/mail";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { ParseError } from "../errors/ParseError";
 import { receivedMailToDomain } from "../mappers/mailMapper";
-import manaboProviderInstance, { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
+import "../providers/chukyo-univ/manaboProvider";
+import type { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
 
 export interface MailRepository {
     /**
@@ -53,7 +56,7 @@ export class IntegratedClassRepositoryMailRepository implements MailRepository {
      * リポジトリを初期化します。
      * @param manaboProvider Manaboプロバイダーの差し替え用インスタンス
      */
-    constructor({ manaboProvider = manaboProviderInstance }: { manaboProvider?: ManaboProvider } = {}) {
+    constructor({ manaboProvider }: { manaboProvider: ManaboProvider }) {
         this.manaboProvider = manaboProvider;
     }
 
@@ -139,5 +142,11 @@ export class IntegratedClassRepositoryMailRepository implements MailRepository {
     }
 }
 
-const mailRepositoryInstance = new IntegratedClassRepositoryMailRepository();
+diContainer.registerSingleton(DI_TOKENS.mailRepository, (container) =>
+    new IntegratedClassRepositoryMailRepository({
+        manaboProvider: container.resolve<ManaboProvider>(DI_TOKENS.manaboProvider),
+    })
+);
+
+const mailRepositoryInstance = diContainer.resolve<MailRepository>(DI_TOKENS.mailRepository);
 export default mailRepositoryInstance;

--- a/src/data/repositories/newsRepository.ts
+++ b/src/data/repositories/newsRepository.ts
@@ -1,10 +1,14 @@
 import * as parser from "@chukyo-passpal/web_parser";
 
 import { AlboNewsInfo } from "@/src/domain/models/news";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { ParseError } from "../errors/ParseError";
 import { alboNewsToDomain } from "../mappers/newsMapper";
-import alboProviderInstance, { AlboProvider } from "../providers/chukyo-univ/alboProvider";
-import manaboProviderInstance, { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
+import "../providers/chukyo-univ/alboProvider";
+import "../providers/chukyo-univ/manaboProvider";
+import type { AlboProvider } from "../providers/chukyo-univ/alboProvider";
+import type { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
 
 export interface NewsRepository {
     /**
@@ -32,9 +36,9 @@ export class IntegratedNewsRepository implements NewsRepository {
      * @param alboProvider Alboプロバイダー
      */
     constructor({
-        manaboProvider = manaboProviderInstance,
-        alboProvider = alboProviderInstance,
-    }: { manaboProvider?: ManaboProvider; alboProvider?: AlboProvider } = {}) {
+        manaboProvider,
+        alboProvider,
+    }: { manaboProvider: ManaboProvider; alboProvider: AlboProvider }) {
         this.manaboProvider = manaboProvider;
         this.alboProvider = alboProvider;
     }
@@ -67,5 +71,12 @@ export class IntegratedNewsRepository implements NewsRepository {
     }
 }
 
-const newsRepositoryInstance = new IntegratedNewsRepository();
+diContainer.registerSingleton(DI_TOKENS.newsRepository, (container) =>
+    new IntegratedNewsRepository({
+        manaboProvider: container.resolve<ManaboProvider>(DI_TOKENS.manaboProvider),
+        alboProvider: container.resolve<AlboProvider>(DI_TOKENS.alboProvider),
+    })
+);
+
+const newsRepositoryInstance = diContainer.resolve<NewsRepository>(DI_TOKENS.newsRepository);
 export default newsRepositoryInstance;

--- a/src/data/repositories/timetableRepository.ts
+++ b/src/data/repositories/timetableRepository.ts
@@ -1,10 +1,14 @@
 import * as parser from "@chukyo-passpal/web_parser";
 
 import { TimetableData } from "@/src/domain/models/timetable";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { ParseError } from "../errors/ParseError";
 import { cubicsTimetableToDomain, manaboTimetableToDomain } from "../mappers/timetableMapper";
-import cubicsProviderInstance, { CubicsProvider } from "../providers/chukyo-univ/cubicsProvider";
-import manaboProviderInstance, { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
+import "../providers/chukyo-univ/cubicsProvider";
+import "../providers/chukyo-univ/manaboProvider";
+import type { CubicsProvider } from "../providers/chukyo-univ/cubicsProvider";
+import type { ManaboProvider } from "../providers/chukyo-univ/manaboProvider";
 
 export interface TimetableRepository {
     // マナボ時間割取得
@@ -33,9 +37,9 @@ export class IntegratedTimetableRepository implements TimetableRepository {
      * @param cubicsProvider Cubicsプロバイダー
      */
     constructor({
-        manaboProvider = manaboProviderInstance,
-        cubicsProvider = cubicsProviderInstance,
-    }: { manaboProvider?: ManaboProvider; cubicsProvider?: CubicsProvider } = {}) {
+        manaboProvider,
+        cubicsProvider,
+    }: { manaboProvider: ManaboProvider; cubicsProvider: CubicsProvider }) {
         this.manaboProvider = manaboProvider;
         this.cubicsProvider = cubicsProvider;
     }
@@ -81,5 +85,12 @@ export class IntegratedTimetableRepository implements TimetableRepository {
     }
 }
 
-const timetableRepositoryInstance = new IntegratedTimetableRepository();
+diContainer.registerSingleton(DI_TOKENS.timetableRepository, (container) =>
+    new IntegratedTimetableRepository({
+        manaboProvider: container.resolve<ManaboProvider>(DI_TOKENS.manaboProvider),
+        cubicsProvider: container.resolve<CubicsProvider>(DI_TOKENS.cubicsProvider),
+    })
+);
+
+const timetableRepositoryInstance = diContainer.resolve<TimetableRepository>(DI_TOKENS.timetableRepository);
 export default timetableRepositoryInstance;

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -1,0 +1,29 @@
+import type { DiToken } from "./tokens";
+
+type Factory<T> = (container: DIContainer) => T;
+
+export class DIContainer {
+    private readonly singletons = new Map<DiToken, unknown>();
+    private readonly factories = new Map<DiToken, Factory<unknown>>();
+
+    public registerSingleton<T>(token: DiToken, factory: Factory<T>): void {
+        if (this.factories.has(token)) {
+            throw new Error(`Token \"${token}\" is already registered.`);
+        }
+        this.factories.set(token, factory as Factory<unknown>);
+    }
+
+    public resolve<T>(token: DiToken): T {
+        if (!this.singletons.has(token)) {
+            const factory = this.factories.get(token);
+            if (!factory) {
+                throw new Error(`Token \"${token}\" is not registered.`);
+            }
+            const instance = factory(this);
+            this.singletons.set(token, instance);
+        }
+        return this.singletons.get(token) as T;
+    }
+}
+
+export const diContainer = new DIContainer();

--- a/src/di/tokens.ts
+++ b/src/di/tokens.ts
@@ -1,0 +1,31 @@
+export const DI_TOKENS = {
+    // providers
+    manaboProvider: "manaboProvider",
+    alboProvider: "alboProvider",
+    cubicsProvider: "cubicsProvider",
+    palAPIProvider: "palAPIProvider",
+    remoteConfigProvider: "remoteConfigProvider",
+
+    // repositories
+    authRepository: "authRepository",
+    adminRepository: "adminRepository",
+    assignmentRepository: "assignmentRepository",
+    classRepository: "classRepository",
+    mailRepository: "mailRepository",
+    newsRepository: "newsRepository",
+    timetableRepository: "timetableRepository",
+
+    // services
+    authService: "authService",
+    authCoordinator: "authCoordinator",
+    eventService: "eventService",
+    assignmentService: "assignmentService",
+    classService: "classService",
+    mailService: "mailService",
+    newsService: "newsService",
+    timetableService: "timetableService",
+    appService: "appService",
+    notificationService: "notificationService",
+} as const;
+
+export type DiToken = (typeof DI_TOKENS)[keyof typeof DI_TOKENS];

--- a/src/domain/services/appService.ts
+++ b/src/domain/services/appService.ts
@@ -1,7 +1,10 @@
 import * as Application from "expo-application";
 import * as Updates from "expo-updates";
 
-import adminRepositoryInstance, { AdminRepository } from "@/src/data/repositories/adminRepository";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
+import "@/src/data/repositories/adminRepository";
+import type { AdminRepository } from "@/src/data/repositories/adminRepository";
 
 export interface AppService {
     /**
@@ -41,9 +44,9 @@ export interface AppService {
 }
 
 export class IntegratedAppService implements AppService {
-    private readonly adminRepository;
+    private readonly adminRepository: AdminRepository;
 
-    constructor(adminRepository: AdminRepository = adminRepositoryInstance) {
+    constructor(adminRepository: AdminRepository) {
         this.adminRepository = adminRepository;
     }
 
@@ -100,5 +103,9 @@ export class IntegratedAppService implements AppService {
     }
 }
 
-const appServiceInstance = new IntegratedAppService();
+diContainer.registerSingleton(DI_TOKENS.appService, (container) =>
+    new IntegratedAppService(container.resolve<AdminRepository>(DI_TOKENS.adminRepository))
+);
+
+const appServiceInstance = diContainer.resolve<AppService>(DI_TOKENS.appService);
 export default appServiceInstance;

--- a/src/domain/services/assignmentService.ts
+++ b/src/domain/services/assignmentService.ts
@@ -1,4 +1,7 @@
-import classRepositoryInstance, { ClassRepository } from "@/src/data/repositories/classRepository";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
+import "@/src/data/repositories/classRepository";
+import type { ClassRepository } from "@/src/data/repositories/classRepository";
 import { Theme } from "@/src/utils/theme";
 import { AssignmentStatus } from "../constants/assignment";
 import { AssignmentClassData, AssignmentDirectoryData, AssignmentInfo } from "../models/assignment";
@@ -113,7 +116,7 @@ export class IntegratedAssignmentService implements AssignmentService {
      * 課題サービスを初期化します。
      * @param classRepository 授業情報を扱うリポジトリ
      */
-    constructor(classRepository = classRepositoryInstance) {
+    constructor(classRepository: ClassRepository) {
         this.classRepository = classRepository;
     }
 
@@ -340,7 +343,11 @@ export class IntegratedAssignmentService implements AssignmentService {
     }
 }
 
-const assignmentServiceInstance = new IntegratedAssignmentService();
+diContainer.registerSingleton(DI_TOKENS.assignmentService, (container) =>
+    new IntegratedAssignmentService(container.resolve<ClassRepository>(DI_TOKENS.classRepository))
+);
+
+const assignmentServiceInstance = diContainer.resolve<AssignmentService>(DI_TOKENS.assignmentService);
 export default assignmentServiceInstance;
 
 export type AssignmentFilter = "all" | "not-started" | "completed" | "expired";

--- a/src/domain/services/authCoordinator.ts
+++ b/src/domain/services/authCoordinator.ts
@@ -1,3 +1,7 @@
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
+import "@/src/data/repositories/authRepository";
+import "./authService";
 import {
     signInWithCredential as firebaseSignInInWithCredential,
     getAuth,
@@ -12,7 +16,7 @@ import {
 } from "@react-native-google-signin/google-signin";
 
 import { AuthProcessError } from "@/src/data/errors/AuthError";
-import authRepositoryInstance from "@/src/data/repositories/authRepository";
+import type { AuthRepository } from "@/src/data/repositories/authRepository";
 import useAssignment from "@/src/presentation/hooks/useAssignment";
 import useAuth from "@/src/presentation/hooks/useAuth";
 import useClass from "@/src/presentation/hooks/useClass";
@@ -20,7 +24,7 @@ import useMail from "@/src/presentation/hooks/useMail";
 import useNews from "@/src/presentation/hooks/useNews";
 import useSetting from "@/src/presentation/hooks/useSetting";
 import useTimetable from "@/src/presentation/hooks/useTimetable";
-import authServiceInstance from "./authService";
+import type { AuthService } from "./authService";
 
 export type GoogleSignInFlowResult =
     | { kind: "success"; studentId: string; firebaseUser: SignInSuccessResponse["data"] }
@@ -66,10 +70,15 @@ export interface AuthCoordinator {
 }
 
 export class IntegratedAuthService implements AuthCoordinator {
+    constructor(
+        private readonly authRepository: AuthRepository,
+        private readonly authService: AuthService
+    ) {}
+
     public configure(): void {
         GoogleSignin.configure({
-            hostedDomain: authServiceInstance.allowedMailDomain,
-            webClientId: authServiceInstance.webClientId,
+            hostedDomain: this.authService.allowedMailDomain,
+            webClientId: this.authService.webClientId,
             offlineAccess: true,
         });
     }
@@ -98,11 +107,11 @@ export class IntegratedAuthService implements AuthCoordinator {
 
             // メールドメインの検証
             const email = response.data.user.email;
-            if (!email.endsWith(authServiceInstance.allowedMailDomain)) {
+            if (!email.endsWith(this.authService.allowedMailDomain)) {
                 return {
                     kind: "invalid-domain",
                     email,
-                    allowedDomain: authServiceInstance.allowedMailDomain,
+                    allowedDomain: this.authService.allowedMailDomain,
                 };
             }
 
@@ -110,7 +119,7 @@ export class IntegratedAuthService implements AuthCoordinator {
             const firebaseIdToken = await this.getFirebaseIdToken();
             const firebaseUser = response.data;
             // PalAPIにログイン
-            authRepositoryInstance.login(firebaseIdToken);
+            this.authRepository.login(firebaseIdToken);
             // Firebaseユーザー情報をストアに保存
             useAuth.getState().setFirebaseUser(firebaseUser);
 
@@ -186,5 +195,12 @@ export class IntegratedAuthService implements AuthCoordinator {
     }
 }
 
-const authCoordinatorInstance = new IntegratedAuthService();
+diContainer.registerSingleton(DI_TOKENS.authCoordinator, (container) =>
+    new IntegratedAuthService(
+        container.resolve<AuthRepository>(DI_TOKENS.authRepository),
+        container.resolve<AuthService>(DI_TOKENS.authService)
+    )
+);
+
+const authCoordinatorInstance = diContainer.resolve<AuthCoordinator>(DI_TOKENS.authCoordinator);
 export default authCoordinatorInstance;

--- a/src/domain/services/authService.ts
+++ b/src/domain/services/authService.ts
@@ -1,12 +1,10 @@
-
-
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import { shibbolethWebViewAuthFunction } from "@/src/data/clients/chukyoShibboleth";
-import authRepositoryInstance from "@/src/data/repositories/authRepository";
+import "@/src/data/repositories/authRepository";
+import type { AuthRepository } from "@/src/data/repositories/authRepository";
 
 import { NotSetError } from "../errors/serviceError";
-
-
-
 export interface AuthService {
     /**
      * Googleサインインで許可するメールドメイン
@@ -46,7 +44,7 @@ export interface AuthService {
 export class IntegratedAuthService implements AuthService {
     protected chukyoShibbolethAuth?: shibbolethWebViewAuthFunction;
     protected shibAuthQueue: Promise<void> = Promise.resolve();
-    protected authRepository = authRepositoryInstance;
+    constructor(private readonly authRepository: AuthRepository) {}
 
     public get allowedMailDomain(): string {
         return this.authRepository.allowedMailDomain;
@@ -83,5 +81,9 @@ export class IntegratedAuthService implements AuthService {
 
 }
 
-const authServiceInstance = new IntegratedAuthService();
+diContainer.registerSingleton(DI_TOKENS.authService, (container) =>
+    new IntegratedAuthService(container.resolve<AuthRepository>(DI_TOKENS.authRepository))
+);
+
+const authServiceInstance = diContainer.resolve<AuthService>(DI_TOKENS.authService);
 export default authServiceInstance;

--- a/src/domain/services/classService.ts
+++ b/src/domain/services/classService.ts
@@ -1,4 +1,7 @@
-import classRepositoryInstance, { ClassRepository } from "@/src/data/repositories/classRepository";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
+import "@/src/data/repositories/classRepository";
+import type { ClassRepository } from "@/src/data/repositories/classRepository";
 import { Period } from "../constants/period";
 import { Weekday } from "../constants/week";
 import { DataBuildError } from "../errors/serviceError";
@@ -43,7 +46,7 @@ export class IntegratedClassService implements ClassService {
      * 授業サービスを初期化します。
      * @param classRepository 授業関連データを扱うリポジトリ
      */
-    constructor(classRepository = classRepositoryInstance) {
+    constructor(classRepository: ClassRepository) {
         this.classRepository = classRepository;
     }
 
@@ -193,7 +196,11 @@ export class IntegratedClassService implements ClassService {
     }
 }
 
-const classServiceInstance = new IntegratedClassService();
+diContainer.registerSingleton(DI_TOKENS.classService, (container) =>
+    new IntegratedClassService(container.resolve<ClassRepository>(DI_TOKENS.classRepository))
+);
+
+const classServiceInstance = diContainer.resolve<ClassService>(DI_TOKENS.classService);
 export default classServiceInstance;
 
 export interface AttendanceStatsSummary {

--- a/src/domain/services/eventService.ts
+++ b/src/domain/services/eventService.ts
@@ -1,5 +1,9 @@
-import remoteConfigProviderInstance from "@/src/data/providers/firebase/remoteConfigProvider";
-import authCoordinatorInstance from "./authCoordinator";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
+import "@/src/data/providers/firebase/remoteConfigProvider";
+import type { RemoteConfigProvider } from "@/src/data/providers/firebase/remoteConfigProvider";
+import "./authCoordinator";
+import type { AuthCoordinator } from "./authCoordinator";
 
 export interface EventService {
     /**
@@ -9,12 +13,24 @@ export interface EventService {
 }
 
 export class IntegratedEventService implements EventService {
+    constructor(
+        private readonly remoteConfigProvider: RemoteConfigProvider,
+        private readonly authCoordinator: AuthCoordinator
+    ) {}
+
     public async appInit(): Promise<void> {
         // 初期化処理があればここに追加
-        await remoteConfigProviderInstance.fetchRemoteConfig();
-        authCoordinatorInstance.configure();
+        await this.remoteConfigProvider.fetchRemoteConfig();
+        this.authCoordinator.configure();
     }
 }
 
-const eventServiceInstance = new IntegratedEventService();
+diContainer.registerSingleton(DI_TOKENS.eventService, (container) =>
+    new IntegratedEventService(
+        container.resolve<RemoteConfigProvider>(DI_TOKENS.remoteConfigProvider),
+        container.resolve<AuthCoordinator>(DI_TOKENS.authCoordinator)
+    )
+);
+
+const eventServiceInstance = diContainer.resolve<EventService>(DI_TOKENS.eventService);
 export default eventServiceInstance;

--- a/src/domain/services/mailService.ts
+++ b/src/domain/services/mailService.ts
@@ -1,4 +1,7 @@
-import mailRepositoryInstance, { MailRepository } from "@/src/data/repositories/mailRepository";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
+import "@/src/data/repositories/mailRepository";
+import type { MailRepository } from "@/src/data/repositories/mailRepository";
 import { MailData } from "../models/mail";
 
 export interface MailService {
@@ -17,7 +20,7 @@ export class IntegratedMailService implements MailService {
      * メールサービスを初期化します。
      * @param mailRepository メール取得に利用するリポジトリ
      */
-    constructor(mailRepository = mailRepositoryInstance) {
+    constructor(mailRepository: MailRepository) {
         this.mailRepository = mailRepository;
     }
 
@@ -26,5 +29,9 @@ export class IntegratedMailService implements MailService {
     }
 }
 
-const mailServiceInstance = new IntegratedMailService();
+diContainer.registerSingleton(DI_TOKENS.mailService, (container) =>
+    new IntegratedMailService(container.resolve<MailRepository>(DI_TOKENS.mailRepository))
+);
+
+const mailServiceInstance = diContainer.resolve<MailService>(DI_TOKENS.mailService);
 export default mailServiceInstance;

--- a/src/domain/services/newsService.ts
+++ b/src/domain/services/newsService.ts
@@ -1,4 +1,7 @@
-import newsRepositoryInstance, { NewsRepository } from "@/src/data/repositories/newsRepository";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
+import "@/src/data/repositories/newsRepository";
+import type { NewsRepository } from "@/src/data/repositories/newsRepository";
 import { NewsData } from "../models/news";
 
 export interface NewsService {
@@ -16,7 +19,7 @@ export class IntegratedNewsService implements NewsService {
      * ニュースサービスを初期化します。
      * @param newsRepository ニュース取得に利用するリポジトリ
      */
-    constructor(newsRepository = newsRepositoryInstance) {
+    constructor(newsRepository: NewsRepository) {
         this.newsRepository = newsRepository;
     }
 
@@ -29,5 +32,9 @@ export class IntegratedNewsService implements NewsService {
     }
 }
 
-const newsServiceInstance = new IntegratedNewsService();
+diContainer.registerSingleton(DI_TOKENS.newsService, (container) =>
+    new IntegratedNewsService(container.resolve<NewsRepository>(DI_TOKENS.newsRepository))
+);
+
+const newsServiceInstance = diContainer.resolve<NewsService>(DI_TOKENS.newsService);
 export default newsServiceInstance;

--- a/src/domain/services/notificationService.ts
+++ b/src/domain/services/notificationService.ts
@@ -1,3 +1,5 @@
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
 import * as Notifications from "expo-notifications";
 
 export interface NotificationService {
@@ -46,5 +48,7 @@ export class IntegratedNotificationService implements NotificationService {
     }
 }
 
-const notificationServiceInstance = new IntegratedNotificationService();
+diContainer.registerSingleton(DI_TOKENS.notificationService, () => new IntegratedNotificationService());
+
+const notificationServiceInstance = diContainer.resolve<NotificationService>(DI_TOKENS.notificationService);
 export default notificationServiceInstance;

--- a/src/domain/services/timetableService.ts
+++ b/src/domain/services/timetableService.ts
@@ -1,4 +1,7 @@
-import timetableRepositoryInstance, { TimetableRepository } from "@/src/data/repositories/timetableRepository";
+import { diContainer } from "@/src/di/container";
+import { DI_TOKENS } from "@/src/di/tokens";
+import "@/src/data/repositories/timetableRepository";
+import type { TimetableRepository } from "@/src/data/repositories/timetableRepository";
 import { Campus } from "../constants/chukyo-univ";
 import { Period } from "../constants/period";
 import { Weekday } from "../constants/week";
@@ -80,7 +83,7 @@ export class IntegratedTimetableService implements TimetableService {
      * サービスを初期化し、時間割リポジトリを設定します。
      * @param timetableRepository 時間割取得に利用するリポジトリ
      */
-    constructor(timetableRepository: TimetableRepository = timetableRepositoryInstance) {
+    constructor(timetableRepository: TimetableRepository) {
         this.timetableRepository = timetableRepository;
     }
 
@@ -141,5 +144,9 @@ export class IntegratedTimetableService implements TimetableService {
     }
 }
 
-const timetableServiceInstance = new IntegratedTimetableService();
+diContainer.registerSingleton(DI_TOKENS.timetableService, (container) =>
+    new IntegratedTimetableService(container.resolve<TimetableRepository>(DI_TOKENS.timetableRepository))
+);
+
+const timetableServiceInstance = diContainer.resolve<TimetableService>(DI_TOKENS.timetableService);
 export default timetableServiceInstance;


### PR DESCRIPTION
## Summary
- introduce a lightweight DI container and tokens to register dependencies
- update providers, repositories, and domain services to register with and resolve from the container instead of constructing singletons directly
- ensure dependent modules load their registrations via side-effect imports so presentation hooks can keep consuming the same default instances

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6909de801a0c83219c924c4eca7a4049